### PR TITLE
Removed trailing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/KyleAMathews/react-sparkline/issues"
   },
   "dependencies": {
-    "d3": "^3.5.5",
+    "d3": "^3.5.5"
   },
   "devDependencies": {
     "cjsx-loader": "^2.0.1",


### PR DESCRIPTION
That comma in package.json is causing `npm install` error:
```
npm ERR! install Couldn't read dependencies
npm ERR! Darwin 14.3.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.2
npm ERR! npm  v2.7.4
npm ERR! file /Users/sahat/Developer/react-sparkline/package.json
npm ERR! code EJSONPARSE

npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 11:3
npm ERR!   },
npm ERR!   ^
npm ERR! File: /Users/sahat/Developer/react-sparkline/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/sahat/Developer/react-sparkline/npm-debug.log
```