### PR TITLE
Preserve aspect ratio

### DIFF
--- a/examples/examples.cjsx
+++ b/examples/examples.cjsx
@@ -71,7 +71,9 @@ module.exports = React.createClass
         strokeColor='green'
         strokeWidth='5px'
         interpolate='none'
-        circleDiameter=10 />
+        circleDiameter=10
+        viewBox="0 0 200 40"
+        preserveAspectRatio="xMidYMid meet" />
         """}
       </code></pre>
       <Sparkline
@@ -80,7 +82,9 @@ module.exports = React.createClass
         strokeColor='green'
         strokeWidth='5px'
         interpolate='none'
-        circleDiameter=10 />
+        circleDiameter=10
+        viewBox="0 0 200 40"
+        preserveAspectRatio="xMidYMid meet" />
       <br />
 
       <h2>Updating data</h2>

--- a/examples/examples.cjsx
+++ b/examples/examples.cjsx
@@ -72,7 +72,6 @@ module.exports = React.createClass
         strokeWidth='5px'
         interpolate='none'
         circleDiameter=10
-        viewBox="0 0 200 40"
         preserveAspectRatio="xMidYMid meet" />
         """}
       </code></pre>

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -12,7 +12,11 @@ module.exports = React.createClass
       interpolate: 'basis'
       circleDiameter: 1.5
       data: [1,23,5,5,23,0,0,0,4,32,3,12,3,1,24,1,5,5,24,23] # Some semi-random data.
+      preserveAspectRatio: 'xMidYMid meet'
     }
+  
+  getViewBox: ->
+    "0 0 #{@props.width} #{@props.height}"
 
   componentDidMount: ->
     @renderSparkline()
@@ -74,6 +78,8 @@ module.exports = React.createClass
       .append('svg')
       .attr('width', @props.width)
       .attr('height', @props.height)
+      .attr('viewBox', @getViewBox())
+      .attr('preserveAspectRatio', @props.preserveAspectRatio)
       .append('g')
 
     svg.append('path')


### PR DESCRIPTION
Add `viewBox` and `preserveAspectRatio` attributes to `svg` element.

Without `viewBox` and `preserveAspectRatio` you can't resize an SVG element with CSS and have its content scale with it. The default settings should have no impact on the default behaviour, but will enable you to set props to allow arbitrary resizing.

This change is necessary to have responsive sparklines.
