### PR TITLE
React 0.14

### DIFF
--- a/examples/examples.cjsx
+++ b/examples/examples.cjsx
@@ -88,7 +88,7 @@ module.exports = React.createClass
       <br />
 
       <h2>Pass in non-date data</h2>
-      <pre style={"white-space":"pre-wrap"}><code>
+      <pre style={whiteSpace:"pre-wrap"}><code>
       {"""
       <Sparkline
         data={[48999,89163,60000,99526,89736,89963,97176]}
@@ -105,7 +105,7 @@ module.exports = React.createClass
       <br />
 
       <h2>Pass in date data</h2>
-      <pre style={"white-space":"pre-wrap"}><code>
+      <pre style={whiteSpace:"pre-wrap"}><code>
       {"""
       dateData = for i in [0..100]
         {
@@ -137,7 +137,7 @@ module.exports = React.createClass
       <br />
 
       <h2>If no data is passed in, an empty div is returned</h2>
-      <pre style={"white-space":"pre-wrap"}><code>
+      <pre style={whiteSpace:"pre-wrap"}><code>
         {"<Sparkline data={[]} />"}
       </code></pre>
       <Sparkline data={[]} />

--- a/examples/index.cjsx
+++ b/examples/index.cjsx
@@ -1,4 +1,5 @@
 React = require('react')
+ReactDOM = require('react-dom');
 Examples = require './examples'
 
-React.render(<Examples />, document.body)
+ReactDOM.render(<Examples />, document.body)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "coffee-script": "^1.9.1",
     "css-loader": "^0.9.1",
     "faker": "^2.1.2",
-    "react": "^0.13.1",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-hot-loader": "^1.2.4",
     "react-simple-table": "^0.5.0",
     "style-loader": "^0.9.0",
@@ -34,7 +35,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   },
   "repository": {
     "type": "git",

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+ReactDOM = require 'react-dom'
 d3 = require 'd3'
 
 module.exports = React.createClass
@@ -25,7 +26,7 @@ module.exports = React.createClass
 
   renderSparkline: () ->
     # If the sparkline has already been rendered, remove it.
-    el = @getDOMNode()
+    el = ReactDOM.findDOMNode(@)
     while (el.firstChild)
       el.removeChild(el.firstChild)
 
@@ -70,7 +71,7 @@ module.exports = React.createClass
       lastX = x(data.length - 1)
       lastY = y(data[data.length - 1])
 
-    svg = d3.select(@getDOMNode())
+    svg = d3.select(ReactDOM.findDOMNode(@))
       .append('svg')
       .attr('width', @props.width)
       .attr('height', @props.height)


### PR DESCRIPTION
- use ReactDOM.findDOMNode(c) instead of c.getDOMNode()
- use ReactDOM.render instead of React.render
- fixed a warning